### PR TITLE
Use communication/ from its subdirectory location.

### DIFF
--- a/docker/dockerfiles/node/Dockerfile
+++ b/docker/dockerfiles/node/Dockerfile
@@ -2,7 +2,6 @@
 FROM concord-builder AS concord-build
 
 # The build context should be the root of the repository.
-COPY ./communication /communication
 
 ## Copy the blockchain repo .git directory so submodules can run git commands
 ## While this is somewhat dirty it makes the relative path in

--- a/proto/CMakeLists.txt
+++ b/proto/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 # The base path of the concord-communcation module, where we're keeping
 # shared resources for services that communicate with concord nodes.
-set(COMMUNICATION_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../communication")
+set(COMMUNICATION_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../communication")
 
 set(PROTOBUF_IMPORT_DIRS ${COMMUNICATION_PATH}/src/main/proto/)
 


### PR DESCRIPTION
In our closed-source repo, communication/ is a sibling to
concord/. Here, it is a child. By using it in its child location,
instead of its sibling location, it is also possible to `mkdir build
&& cd build && cmake .. && make -j4` outside of docker, if you have
the other dependencies installed appropriately.

