### PR TITLE
Build ethrpc from openjdk, and remove java from concord-builder

### DIFF
--- a/docker/dockerfiles/builder/Dockerfile
+++ b/docker/dockerfiles/builder/Dockerfile
@@ -39,8 +39,6 @@ RUN apt-get update && apt-get -y install \
     python2.7 \
     python3-pip \
     wget \
-    default-jre \
-    default-jdk \
     && rm -rf /var/lib/apt/lists/*
 
 RUN ln -s /usr/bin/clang-format-7 /usr/bin/clang-format

--- a/docker/dockerfiles/ethrpc/Dockerfile
+++ b/docker/dockerfiles/ethrpc/Dockerfile
@@ -25,7 +25,7 @@ COPY ./tools/ethrpc/src ./ethrpc/src
 RUN mvn -f ethrpc/pom.xml package
 
 ## Runtime image.
-FROM concord-builder
+FROM openjdk:11.0.4-jdk-slim-buster
 LABEL description="RPC Server for Ethereum API"
 
 WORKDIR /ethrpc


### PR DESCRIPTION
This both makes the ethrpc runtime image smaller, and also removes
unnecessary libraries from the concord build image.

