### PR TITLE
Update evmjit to latest version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,62 @@
+// For format details, see https://aka.ms/vscode-remote/devcontainer.json or the definition README at
+// https://github.com/microsoft/vscode-dev-containers/tree/master/containers/docker-existing-dockerfile
+{
+	"name": "Concord-Builder",
+
+	// Set the workspace folder name to /concord (expected by the build scripts)
+	"workspaceFolder": "/workspace/concord",
+	"workspaceMount": "src=${localWorkspaceFolder},dst=/workspace/concord,type=bind,consistency=delegated",
+
+	// Sets the run context to one level up instead of the .devcontainer folder.
+	"context": "..",
+
+	// Update the 'dockerFile' property if you aren't using the standard 'Dockerfile' filename.
+	"dockerFile": "../docker/dockerfiles/builder/Dockerfile",
+
+	
+	// The optional 'runArgs' property can be used to specify additional runtime arguments.
+	"runArgs": [
+		"--hostname", "concord1",
+		"-v", "${localWorkspaceFolder}/docker/resources/devdata/rocksdbdata1:/concord/rocksdbdata",
+		"-v", "${localWorkspaceFolder}/docker/resources/devdata/log1:/concord/log",
+		"-v", "${localWorkspaceFolder}/docker/resources/config-concord1:/concord/config-local",
+		"-v", "${localWorkspaceFolder}/docker/resources/config-public:/concord/config-public:ro",
+		"-v", "${localWorkspaceFolder}/docker/resources/tls_certs:/concord/tls_certs:ro",
+		"--expose", "3501",
+		"--expose", "3502",
+		"--expose", "3503",
+		"--expose", "3504",
+		"--expose", "3505",
+		"-p", "5858:5848",
+		"--network", "compose_default",
+		"--network-alias", "concord1"
+		// Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-in-docker for details.
+		// "-v","/var/run/docker.sock:/var/run/docker.sock",
+
+		// Uncomment the next line if you will be using a ptrace-based debugger like C++, Go, and Rust.
+		// "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined"
+
+		// You may want to add a non-root user to your Dockerfile. On Linux, this will prevent
+		// new files getting created as root. See https://aka.ms/vscode-remote/containers/non-root-user
+		// for the needed Dockerfile updates and then uncomment the next line.
+		// "-u", "vscode"
+	],
+
+	// Use 'settings' to set *default* container specific settings.json values on container create. 
+	// You can edit these settings after create using File > Preferences > Settings > Remote.
+	"settings": { 
+		// This will ignore your local shell user setting for Linux since shells like zsh are typically 
+		// not in base container images. You can also update this to an specific shell to ensure VS Code 
+		// uses the right one for terminals and tasks. For example, /bin/bash (or /bin/ash for Alpine).
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Uncomment the next line if you want to publish any ports.
+	// "appPort": [],
+
+	// Uncomment the next line to run commands after the container is created - for example installing git.
+	// "postCreateCommand": "apt-get update && apt-get install -y git",
+
+	// Add the IDs of extensions you want installed when the container is created in the array below.
+	"extensions": [ "vector-of-bool.cmake-tools", "ms-vscode.cpptools"]
+}

--- a/cmake/FindEvmjit.cmake
+++ b/cmake/FindEvmjit.cmake
@@ -11,7 +11,7 @@ else(DEFINED EVM_INCLUDE_DIR_NOTFOUND)
    message(STATUS "Evmjit found at " ${Evmjit_INCLUDE_DIR})
    set(Evmjit_FOUND 1)
 
-   set(Evmjit_INCLUDE_DIRS ${Evmjit_INCLUDE_DIR})
+   set(Evmjit_INCLUDE_DIRS ${Evmjit_INCLUDE_DIR} ${Evmjit_INCLUDE_DIR}/../evmc/include)
    link_directories(${Evmjit_INCLUDE_DIR}/../build/libevmjit/
      ${Evmjit_INCLUDE_DIR}/../deps/lib/)
 if(APPLE)

--- a/docker/compose/develop4.yml
+++ b/docker/compose/develop4.yml
@@ -1,0 +1,99 @@
+version: '3'
+services:
+  ethrpc1:
+    image: concord-ethrpc:latest
+    ports:
+      - 8545:8545
+    volumes:
+      - ../resources/config-ethrpc1:/config:ro
+    command:
+      - java
+      - -jar
+      - concord-ethrpc.jar
+      - --ConcordAuthorities=concord1:5458
+  concord2:
+    image: concord-node:latest
+    ports:
+      - 5459:5458
+    expose:
+      - 3501/tcp
+      - 3502/tcp
+      - 3503/tcp
+      - 3504/tcp
+      - 3505/tcp
+    volumes:
+      - ../resources/devdata/rocksdbdata2:/concord/rocksdbdata
+      - ../resources/devdata/log2:/concord/log
+      - ../resources/config-concord2:/concord/config-local
+      - ../resources/config-public:/concord/config-public:ro
+      - ../resources/tls_certs:/concord/tls_certs:ro
+
+  ethrpc2:
+    image: concord-ethrpc:latest
+    ports:
+      - 8546:8545
+    volumes:
+      - ../resources/config-ethrpc2:/config:ro
+    command:
+      - java
+      - -jar
+      - concord-ethrpc.jar
+      - --ConcordAuthorities=concord2:5458
+
+  concord3:
+    image: concord-node:latest
+    ports:
+      - 5460:5458
+    expose:
+      - 3501/tcp
+      - 3502/tcp
+      - 3503/tcp
+      - 3504/tcp
+      - 3505/tcp
+    volumes:
+      - ../resources/devdata/rocksdbdata3:/concord/rocksdbdata
+      - ../resources/devdata/log3:/concord/log
+      - ../resources/config-concord3:/concord/config-local
+      - ../resources/config-public:/concord/config-public:ro
+      - ../resources/tls_certs:/concord/tls_certs:ro
+
+  ethrpc3:
+    image: concord-ethrpc:latest
+    ports:
+      - 8547:8545
+    volumes:
+      - ../resources/config-ethrpc3:/config:ro
+    command:
+      - java
+      - -jar
+      - concord-ethrpc.jar
+      - --ConcordAuthorities=concord3:5458
+
+  concord4:
+    image: concord-node:latest
+    ports:
+      - 5461:5458
+    expose:
+      - 3501/tcp
+      - 3502/tcp
+      - 3503/tcp
+      - 3504/tcp
+      - 3505/tcp
+    volumes:
+      - ../resources/devdata/rocksdbdata4:/concord/rocksdbdata
+      - ../resources/devdata/log4:/concord/log
+      - ../resources/config-concord4:/concord/config-local
+      - ../resources/config-public:/concord/config-public:ro
+      - ../resources/tls_certs:/concord/tls_certs:ro
+
+  ethrpc4:
+    image: concord-ethrpc:latest
+    ports:
+      - 8548:8545
+    volumes:
+      - ../resources/config-ethrpc4:/config:ro
+    command:
+      - java
+      - -jar
+      - concord-ethrpc.jar
+      - --ConcordAuthorities=concord4:5458

--- a/docker/dockerfiles/builder/Dockerfile
+++ b/docker/dockerfiles/builder/Dockerfile
@@ -74,7 +74,8 @@ RUN autoconf && ./configure CXXFLAGS="--std=c++11 -march=x86-64 -mtune=generic" 
 WORKDIR /
 RUN git clone https://github.com/ethereum/evmjit.git && \
     cd /evmjit && \
-    git checkout 4e9f3d76292c7de0c6613427761f843b1719f614
+    git checkout 886941b07370a81ce565f0ffbd9b8595a24ea7a4 && \
+    git submodule update --init --recursive
 WORKDIR /evmjit/build
 RUN cmake -DLLVM_DIR=/usr/lib/llvm-5.0/lib/cmake/llvm -DCMAKE_CXX_FLAGS="-march=x86-64 -mtune=generic" ..
 RUN cmake --build . --config RelWithDebInfo -- -j${MAKE_PARALLELISM}

--- a/src/api/api_connection.cpp
+++ b/src/api/api_connection.cpp
@@ -35,7 +35,7 @@
 #include "api/connection_manager.hpp"
 #include "common/concord_log.hpp"
 #include "consensus/kvb_client.hpp"
-#include "evm.h"
+#include "evmjit.h"
 
 using namespace boost::asio;
 using namespace std;
@@ -57,7 +57,7 @@ using google::protobuf::util::TimeUtil;
 
 using concord::common::StatusAggregator;
 using concord::consensus::KVBClientPool;
-using concord::utils::from_evm_uint256be;
+using concord::utils::from_evmc_uint256be;
 
 namespace concord {
 namespace api {
@@ -704,8 +704,8 @@ void ApiConnection::handle_time_request() {
  */
 bool ApiConnection::is_valid_eth_getStorageAt(const EthRequest &request) {
   if (request.has_addr_to() &&
-      request.addr_to().size() == sizeof(evm_address) && request.has_data() &&
-      request.data().size() == sizeof(evm_uint256be)) {
+      request.addr_to().size() == sizeof(evmc_address) && request.has_data() &&
+      request.data().size() == sizeof(evmc_uint256be)) {
     // must have the address of the contract, and the location to read
     return true;
   } else {
@@ -720,7 +720,7 @@ bool ApiConnection::is_valid_eth_getStorageAt(const EthRequest &request) {
  */
 bool ApiConnection::is_valid_eth_getCode(const EthRequest &request) {
   if (request.has_addr_to() &&
-      request.addr_to().size() == sizeof(evm_address)) {
+      request.addr_to().size() == sizeof(evmc_address)) {
     return true;
   } else {
     ErrorResponse *error = concordResponse_.add_error_response();
@@ -735,7 +735,7 @@ bool ApiConnection::is_valid_eth_getCode(const EthRequest &request) {
 bool ApiConnection::is_valid_eth_getTransactionCount(
     const EthRequest &request) {
   if (request.has_addr_to() &&
-      request.addr_to().size() == sizeof(evm_address)) {
+      request.addr_to().size() == sizeof(evmc_address)) {
     return true;
   } else {
     ErrorResponse *error = concordResponse_.add_error_response();
@@ -749,7 +749,7 @@ bool ApiConnection::is_valid_eth_getTransactionCount(
  */
 bool ApiConnection::is_valid_eth_getBalance(const EthRequest &request) {
   if (request.has_addr_to() &&
-      request.addr_to().size() == sizeof(evm_address)) {
+      request.addr_to().size() == sizeof(evmc_address)) {
     return true;
   } else {
     ErrorResponse *error = concordResponse_.add_error_response();
@@ -782,9 +782,9 @@ uint64_t ApiConnection::current_block_number() {
                                     internalResp)) {
     if (internalResp.eth_response_size() > 0) {
       std::string strblk = internalResp.eth_response(0).data();
-      evm_uint256be rawNumber;
+      evmc_uint256be rawNumber;
       std::copy(strblk.begin(), strblk.end(), rawNumber.bytes);
-      return from_evm_uint256be(&rawNumber);
+      return from_evmc_uint256be(&rawNumber);
     }
   }
 

--- a/src/common/concord_log.cpp
+++ b/src/common/concord_log.cpp
@@ -8,7 +8,7 @@
 #include <ios>
 
 #include "consensus/hex_tools.h"
-#include "evm.h"
+#include "evmjit.h"
 
 namespace concord {
 namespace common {
@@ -23,35 +23,35 @@ std::ostream& operator<<(std::ostream& s, const HexPrintBytes p) {
   return hexPrint(s, reinterpret_cast<const uint8_t*>(p.bytes), p.size);
 };
 
-// Print an evm_address as its 0x<hex> representation.
-std::ostream& operator<<(std::ostream& s, const evm_address& a) {
-  return hexPrint(s, a.bytes, sizeof(evm_address));
+// Print an evmc_address as its 0x<hex> representation.
+std::ostream& operator<<(std::ostream& s, const evmc_address& a) {
+  return hexPrint(s, a.bytes, sizeof(evmc_address));
 };
 
-// Print an evm_uint256be as its 0x<hex> representation.
-std::ostream& operator<<(std::ostream& s, const evm_uint256be& u) {
-  return hexPrint(s, u.bytes, sizeof(evm_uint256be));
+// Print an evmc_uint256be as its 0x<hex> representation.
+std::ostream& operator<<(std::ostream& s, const evmc_uint256be& u) {
+  return hexPrint(s, u.bytes, sizeof(evmc_uint256be));
 };
 
-std::ostream& operator<<(std::ostream& s, evm_call_kind kind) {
+std::ostream& operator<<(std::ostream& s, evmc_call_kind kind) {
   switch (kind) {
-    case EVM_CALL:
-      s << "EVM_CALL";
+    case EVMC_CALL:
+      s << "EVMC_CALL";
       break;
-    case EVM_DELEGATECALL:
-      s << "EVM_DELEGATECALL";
+    case EVMC_DELEGATECALL:
+      s << "EVMC_DELEGATECALL";
       break;
-    case EVM_CALLCODE:
-      s << "EVM_CALLCODE";
+    case EVMC_CALLCODE:
+      s << "EVMC_CALLCODE";
       break;
-    case EVM_CREATE:
-      s << "EVM_CREATE";
+    case EVMC_CREATE:
+      s << "EVMC_CREATE";
       break;
   }
   return s;
 }
 
-std::ostream& operator<<(std::ostream& s, struct evm_message msg) {
+std::ostream& operator<<(std::ostream& s, struct evmc_message msg) {
   s << "\nMessage: {\ndestination: " << msg.destination
     << "\nsender: " << msg.sender << "\nether: " << msg.value
     << "\ncall_kind: " << msg.kind << "\ndepth: " << msg.depth

--- a/src/common/concord_log.hpp
+++ b/src/common/concord_log.hpp
@@ -10,7 +10,7 @@
 
 #include <ostream>
 #include <vector>
-#include "evm.h"
+#include "evmjit.h"
 
 namespace concord {
 namespace common {
@@ -26,10 +26,10 @@ struct HexPrintBytes {
 
 std::ostream& operator<<(std::ostream& s, HexPrintVector v);
 std::ostream& operator<<(std::ostream& s, HexPrintBytes p);
-std::ostream& operator<<(std::ostream& s, const evm_uint256be& u);
-std::ostream& operator<<(std::ostream& s, const evm_address& u);
-std::ostream& operator<<(std::ostream& s, struct evm_message msg);
-std::ostream& operator<<(std::ostream& s, evm_call_kind kind);
+std::ostream& operator<<(std::ostream& s, const evmc_uint256be& u);
+std::ostream& operator<<(std::ostream& s, const evmc_address& u);
+std::ostream& operator<<(std::ostream& s, struct evmc_message msg);
+std::ostream& operator<<(std::ostream& s, evmc_call_kind kind);
 
 }  // namespace common
 }  // namespace concord

--- a/src/common/concord_types.hpp
+++ b/src/common/concord_types.hpp
@@ -13,38 +13,38 @@
 namespace concord {
 namespace common {
 
-const evm_address zero_address{{0}};
-const evm_uint256be zero_hash{{0}};
+const evmc_address zero_address{{0}};
+const evmc_uint256be zero_hash{{0}};
 
 const int64_t tx_storage_version = 1;
 const int64_t blk_storage_version = 1;
 
 typedef struct EthLog {
-  evm_address address;
-  std::vector<evm_uint256be> topics;
+  evmc_address address;
+  std::vector<evmc_uint256be> topics;
   std::vector<uint8_t> data;
 } EthLog;
 
 typedef struct EthTransaction {
   uint64_t nonce;
-  evm_uint256be block_hash;
+  evmc_uint256be block_hash;
   uint64_t block_number;
-  evm_address from;
-  evm_address to;
-  evm_address contract_address;
+  evmc_address from;
+  evmc_address to;
+  evmc_address contract_address;
   std::vector<uint8_t> input;
-  evm_status_code status;
-  evm_uint256be value;
+  evmc_status_code status;
+  evmc_uint256be value;
   uint64_t gas_price;
   uint64_t gas_limit;
   uint64_t gas_used;
   std::vector<EthLog> logs;
-  evm_uint256be sig_r;
-  evm_uint256be sig_s;
+  evmc_uint256be sig_r;
+  evmc_uint256be sig_s;
   uint64_t sig_v;
 
   std::vector<uint8_t> rlp() const;
-  evm_uint256be hash() const;
+  evmc_uint256be hash() const;
   size_t serialize(uint8_t **out);
   static struct EthTransaction deserialize(concord::consensus::Sliver &input);
 } EthTransaction;
@@ -52,13 +52,13 @@ typedef struct EthTransaction {
 typedef struct EthBlock {
   uint64_t number;
   uint64_t timestamp;
-  evm_uint256be hash;
-  evm_uint256be parent_hash;
+  evmc_uint256be hash;
+  evmc_uint256be parent_hash;
   uint64_t gas_limit;
   uint64_t gas_used;
-  std::vector<evm_uint256be> transactions;
+  std::vector<evmc_uint256be> transactions;
 
-  evm_uint256be get_hash() const;
+  evmc_uint256be get_hash() const;
   size_t serialize(uint8_t **out);
   static struct EthBlock deserialize(concord::consensus::Sliver &input);
 } EthBlock;
@@ -66,13 +66,13 @@ typedef struct EthBlock {
 }  // namespace common
 }  // namespace concord
 
-// Byte-wise comparators for evm_uint256be and evm_address. This allows us to
+// Byte-wise comparators for evmc_uint256be and evmc_address. This allows us to
 // use these types as keys in a std::map. Must be in the global namespace.
-bool operator<(const evm_uint256be &a, const evm_uint256be &b);
-bool operator!=(const evm_uint256be &a, const evm_uint256be &b);
-bool operator==(const evm_uint256be &a, const evm_uint256be &b);
-bool operator<(const evm_address &a, const evm_address &b);
-bool operator!=(const evm_address &a, const evm_address &b);
-bool operator==(const evm_address &a, const evm_address &b);
+bool operator<(const evmc_uint256be &a, const evmc_uint256be &b);
+bool operator!=(const evmc_uint256be &a, const evmc_uint256be &b);
+bool operator==(const evmc_uint256be &a, const evmc_uint256be &b);
+bool operator<(const evmc_address &a, const evmc_address &b);
+bool operator!=(const evmc_address &a, const evmc_address &b);
+bool operator==(const evmc_address &a, const evmc_address &b);
 
 #endif  // COMMON_CONCORD_TYPES_HPP

--- a/src/config/configuration_manager.cpp
+++ b/src/config/configuration_manager.cpp
@@ -4023,8 +4023,9 @@ void loadSBFTCryptosystems(ConcordConfiguration& config) {
   }
 
   ConcordPrimaryConfigurationAuxiliaryState* auxState;
-  assert(auxState = dynamic_cast<ConcordPrimaryConfigurationAuxiliaryState*>(
-             config.getAuxiliaryState()));
+  auxState = dynamic_cast<ConcordPrimaryConfigurationAuxiliaryState*>(
+      config.getAuxiliaryState());
+  assert(auxState);
 
   uint16_t fVal = config.getValue<uint16_t>("f_val");
   uint16_t cVal = config.getValue<uint16_t>("c_val");

--- a/src/consensus/bft_configuration.hpp
+++ b/src/consensus/bft_configuration.hpp
@@ -29,9 +29,9 @@ void initializeSBFTThresholdPublicKeys(
     IThresholdVerifier*& thresholdVerifierForCommit,
     IThresholdVerifier*& thresholdVerifierForOptimisticCommit) {
   concord::config::ConcordPrimaryConfigurationAuxiliaryState* auxState;
-  assert(auxState = dynamic_cast<
-             concord::config::ConcordPrimaryConfigurationAuxiliaryState*>(
-             config.getAuxiliaryState()));
+  auxState =
+      dynamic_cast<concord::config::ConcordPrimaryConfigurationAuxiliaryState*>(
+          config.getAuxiliaryState());
 
   if (supportDirectProofs) {
     assert(auxState->executionCryptosys);
@@ -70,9 +70,10 @@ void initializeSBFTThresholdPrivateKeys(
     IThresholdSigner*& thresholdSignerForOptimisticCommit,
     bool supportDirectProofs) {
   concord::config::ConcordPrimaryConfigurationAuxiliaryState* auxState;
-  assert(auxState = dynamic_cast<
-             concord::config::ConcordPrimaryConfigurationAuxiliaryState*>(
-             config.getAuxiliaryState()));
+  auxState =
+      dynamic_cast<concord::config::ConcordPrimaryConfigurationAuxiliaryState*>(
+          config.getAuxiliaryState());
+  assert(auxState);
 
   // f + 1
   if (supportDirectProofs) {

--- a/src/ethereum/eth_kvb_commands_handler.hpp
+++ b/src/ethereum/eth_kvb_commands_handler.hpp
@@ -111,24 +111,24 @@ class EthKvbCommandsHandler
 
   // Utilites
   void build_transaction_response(
-      evm_uint256be &hash, concord::common::EthTransaction &tx,
+      evmc_uint256be &hash, concord::common::EthTransaction &tx,
       com::vmware::concord::TransactionResponse *response) const;
 
   void recover_from(const com::vmware::concord::EthRequest &request,
-                    evm_address *sender) const;
+                    evmc_address *sender) const;
 
   uint64_t parse_block_parameter(
       const com::vmware::concord::EthRequest &request,
       EthKvbStorage &kvbStorage) const;
 
-  evm_result run_evm(const com::vmware::concord::EthRequest &request,
-                     EthKvbStorage &kvbStorage, uint64_t timestamp,
-                     evm_uint256be &txhash /* OUT */);
+  evmc_result run_evm(const com::vmware::concord::EthRequest &request,
+                      EthKvbStorage &kvbStorage, uint64_t timestamp,
+                      evmc_uint256be &txhash /* OUT */);
 
-  evm_uint256be record_transaction(
-      const evm_message &message,
+  evmc_uint256be record_transaction(
+      const evmc_message &message,
       const com::vmware::concord::EthRequest &request, const uint64_t nonce,
-      const evm_result &result, const uint64_t timestamp,
+      const evmc_result &result, const uint64_t timestamp,
       const std::vector<::concord::common::EthLog> &logs,
       EthKvbStorage &kvbStorage) const;
 

--- a/src/ethereum/eth_kvb_storage.hpp
+++ b/src/ethereum/eth_kvb_storage.hpp
@@ -14,7 +14,7 @@
 #include "common/concord_types.hpp"
 #include "consensus/hash_defs.h"
 #include "consensus/sliver.hpp"
-#include "evm.h"
+#include "evmjit.h"
 #include "storage/blockchain_db_types.h"
 #include "storage/blockchain_interfaces.h"
 
@@ -47,15 +47,15 @@ class EthKvbStorage {
 
   concord::consensus::Sliver block_key(
       const concord::common::EthBlock &blk) const;
-  concord::consensus::Sliver block_key(const evm_uint256be &hash) const;
+  concord::consensus::Sliver block_key(const evmc_uint256be &hash) const;
   concord::consensus::Sliver transaction_key(
       const concord::common::EthTransaction &tx) const;
-  concord::consensus::Sliver transaction_key(const evm_uint256be &hash) const;
-  concord::consensus::Sliver balance_key(const evm_address &addr) const;
-  concord::consensus::Sliver nonce_key(const evm_address &addr) const;
-  concord::consensus::Sliver code_key(const evm_address &addr) const;
-  concord::consensus::Sliver storage_key(const evm_address &addr,
-                                         const evm_uint256be &location) const;
+  concord::consensus::Sliver transaction_key(const evmc_uint256be &hash) const;
+  concord::consensus::Sliver balance_key(const evmc_address &addr) const;
+  concord::consensus::Sliver nonce_key(const evmc_address &addr) const;
+  concord::consensus::Sliver code_key(const evmc_address &addr) const;
+  concord::consensus::Sliver storage_key(const evmc_address &addr,
+                                         const evmc_uint256be &location) const;
   concord::consensus::Status get(const concord::consensus::Sliver &key,
                                  concord::consensus::Sliver &out);
   concord::consensus::Status get(const concord::storage::BlockId readVersion,
@@ -84,33 +84,34 @@ class EthKvbStorage {
   const concord::storage::ILocalKeyValueStorageReadOnly &getReadOnlyStorage();
 
   uint64_t current_block_number();
-  concord::common::EthBlock get_block(const evm_uint256be &hash);
+  concord::common::EthBlock get_block(const evmc_uint256be &hash);
   concord::common::EthBlock get_block(uint64_t number);
-  concord::common::EthTransaction get_transaction(const evm_uint256be &hash);
-  evm_uint256be get_balance(const evm_address &addr);
-  evm_uint256be get_balance(const evm_address &addr, uint64_t &block_number);
-  uint64_t get_nonce(const evm_address &addr);
-  uint64_t get_nonce(const evm_address &addr, uint64_t &block_number);
-  bool account_exists(const evm_address &addr);
-  bool get_code(const evm_address &addr, std::vector<uint8_t> &out,
-                evm_uint256be &hash);
-  bool get_code(const evm_address &addr, std::vector<uint8_t> &out,
-                evm_uint256be &hash, uint64_t &block_number);
-  evm_uint256be get_storage(const evm_address &addr,
-                            const evm_uint256be &location);
-  evm_uint256be get_storage(const evm_address &addr,
-                            const evm_uint256be &location,
-                            uint64_t &block_number);
+  concord::common::EthTransaction get_transaction(const evmc_uint256be &hash);
+  evmc_uint256be get_balance(const evmc_address &addr);
+  evmc_uint256be get_balance(const evmc_address &addr, uint64_t &block_number);
+  uint64_t get_nonce(const evmc_address &addr);
+  uint64_t get_nonce(const evmc_address &addr, uint64_t &block_number);
+  bool account_exists(const evmc_address &addr);
+  bool get_code(const evmc_address &addr, std::vector<uint8_t> &out,
+                evmc_uint256be &hash);
+  bool get_code(const evmc_address &addr, std::vector<uint8_t> &out,
+                evmc_uint256be &hash, uint64_t &block_number);
+  evmc_uint256be get_storage(const evmc_address &addr,
+                             const evmc_uint256be &location);
+  evmc_uint256be get_storage(const evmc_address &addr,
+                             const evmc_uint256be &location,
+                             uint64_t &block_number);
 
   concord::consensus::Status write_block(uint64_t timestamp,
                                          uint64_t gas_limit);
   void reset();
   void add_transaction(concord::common::EthTransaction &tx);
-  void set_balance(const evm_address &addr, evm_uint256be balance);
-  void set_nonce(const evm_address &addr, uint64_t nonce);
-  void set_code(const evm_address &addr, const uint8_t *code, size_t code_size);
-  void set_storage(const evm_address &addr, const evm_uint256be &location,
-                   const evm_uint256be &data);
+  void set_balance(const evmc_address &addr, evmc_uint256be balance);
+  void set_nonce(const evmc_address &addr, uint64_t nonce);
+  void set_code(const evmc_address &addr, const uint8_t *code,
+                size_t code_size);
+  void set_storage(const evmc_address &addr, const evmc_uint256be &location,
+                   const evmc_uint256be &data);
 };
 
 }  // namespace ethereum

--- a/src/ethereum/evm_init_params.cpp
+++ b/src/ethereum/evm_init_params.cpp
@@ -38,12 +38,12 @@ EVMInitParams::EVMInitParams(const std::string genesis_file_path)
     json alloc = genesis_block["alloc"];
     for (json::iterator it = alloc.begin(); it != alloc.end(); it++) {
       std::vector<uint8_t> address_v = dehex(it.key());
-      if (address_v.size() != sizeof(evm_address)) {
+      if (address_v.size() != sizeof(evmc_address)) {
         LOG4CPLUS_ERROR(
             logger, "Invalid account address: " << HexPrintVector{address_v});
         throw EVMInitParamException("Invalid 'alloc' section in genesis file");
       }
-      evm_address address;
+      evmc_address address;
       std::copy(address_v.begin(), address_v.end(), address.bytes);
 
       std::string balance_str = it.value()["balance"];
@@ -116,7 +116,7 @@ uint64_t EVMInitParams::parse_number(std::string label, std::string val_str) {
   return val;
 }
 
-const std::map<evm_address, evm_uint256be>
+const std::map<evmc_address, evmc_uint256be>
     &EVMInitParams::get_initial_accounts() const {
   return initial_accounts;
 }

--- a/src/ethereum/evm_init_params.hpp
+++ b/src/ethereum/evm_init_params.hpp
@@ -12,7 +12,7 @@
 #include <stdexcept>
 #include <vector>
 #include "common/concord_types.hpp"
-#include "evm.h"
+#include "evmjit.h"
 #include "utils/concord_utils.hpp"
 #include "utils/json.hpp"
 
@@ -35,7 +35,7 @@ class EVMInitParams {
   explicit EVMInitParams(std::string genesis_file_path);
   nlohmann::json parse_genesis_block(std::string genesis_file_path);
   uint64_t parse_number(std::string label, std::string time_str);
-  const std::map<evm_address, evm_uint256be>& get_initial_accounts() const;
+  const std::map<evmc_address, evmc_uint256be>& get_initial_accounts() const;
   uint64_t get_chainID() const;
   uint64_t get_timestamp() const;
   uint64_t get_gas_limit() const;
@@ -50,7 +50,7 @@ class EVMInitParams {
   // This was the former static value used for the gas limit.
   uint64_t gasLimit = 1000000;
   // The map of initial accounts with their preset balance values
-  std::map<evm_address, evm_uint256be> initial_accounts;
+  std::map<evmc_address, evmc_uint256be> initial_accounts;
 
   log4cplus::Logger logger;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -159,7 +159,7 @@ concord::consensus::Status create_genesis_block(IReplica *replica,
     return concord::consensus::Status::OK();
   }
 
-  std::map<evm_address, evm_uint256be> genesis_acts =
+  std::map<evmc_address, evmc_uint256be> genesis_acts =
       params.get_initial_accounts();
   uint64_t nonce = 0;
   uint64_t chainID = params.get_chainID();
@@ -174,7 +174,7 @@ concord::consensus::Status create_genesis_block(IReplica *replica,
         it->first,               // to
         zero_address,            // contract_address
         std::vector<uint8_t>(),  // input
-        EVM_SUCCESS,             // status
+        EVMC_SUCCESS,            // status
         it->second,              // value
         0,                       // gas_price
         0,                       // gas_limit
@@ -184,7 +184,7 @@ concord::consensus::Status create_genesis_block(IReplica *replica,
         zero_hash,          // sig_s (no signature for genesis)
         (chainID * 2 + 35)  // sig_v
     };
-    evm_uint256be txhash = tx.hash();
+    evmc_uint256be txhash = tx.hash();
     LOG4CPLUS_INFO(logger, "Created genesis transaction "
                                << txhash << " to address " << it->first
                                << " with value = " << tx.value);

--- a/src/utils/concord_eth_hash.cpp
+++ b/src/utils/concord_eth_hash.cpp
@@ -8,22 +8,22 @@
 #include <keccak.h>
 #include <log4cplus/loggingmacros.h>
 
-#include "evm.h"
+#include "evmjit.h"
 
 namespace concord {
 namespace utils {
 namespace eth_hash {
 
-evm_uint256be keccak_hash(const std::vector<uint8_t> &data) {
+evmc_uint256be keccak_hash(const std::vector<uint8_t> &data) {
   return keccak_hash(&data[0], data.size());
 }
 
-evm_uint256be keccak_hash(const uint8_t *data, size_t size) {
-  static_assert(sizeof(evm_uint256be) == CryptoPP::Keccak_256::DIGESTSIZE,
+evmc_uint256be keccak_hash(const uint8_t *data, size_t size) {
+  static_assert(sizeof(evmc_uint256be) == CryptoPP::Keccak_256::DIGESTSIZE,
                 "hash is not the same size as uint256");
 
   CryptoPP::Keccak_256 keccak;
-  evm_uint256be hash;
+  evmc_uint256be hash;
   keccak.CalculateDigest(hash.bytes, data, size);
   return hash;
 }

--- a/src/utils/concord_eth_hash.hpp
+++ b/src/utils/concord_eth_hash.hpp
@@ -7,14 +7,14 @@
 #define UTILS_CONCORD_ETH_HASH_HPP
 
 #include <log4cplus/loggingmacros.h>
-#include "evm.h"
+#include "evmjit.h"
 
 namespace concord {
 namespace utils {
 namespace eth_hash {
 
-evm_uint256be keccak_hash(const std::vector<uint8_t> &data);
-evm_uint256be keccak_hash(const uint8_t *data, size_t size);
+evmc_uint256be keccak_hash(const std::vector<uint8_t> &data);
+evmc_uint256be keccak_hash(const uint8_t *data, size_t size);
 
 }  // namespace eth_hash
 }  // namespace utils

--- a/src/utils/concord_eth_sign.cpp
+++ b/src/utils/concord_eth_sign.cpp
@@ -15,7 +15,7 @@ namespace concord {
 namespace utils {
 
 // TODO: sort out build structure, to pull this from concord_types
-const evm_address zero_address{{0}};
+const evmc_address zero_address{{0}};
 
 EthSign::EthSign()
     : logger(log4cplus::Logger::getInstance("com.vmware.concord.eth_sign")) {
@@ -28,8 +28,8 @@ EthSign::~EthSign() { secp256k1_context_destroy(ctx); }
 /**
  * Sign hash with private key.
  */
-std::vector<uint8_t> EthSign::sign(const evm_uint256be hash,
-                                   const evm_uint256be key) const {
+std::vector<uint8_t> EthSign::sign(const evmc_uint256be hash,
+                                   const evmc_uint256be key) const {
   std::vector<uint8_t> serializedSignature;
   secp256k1_ecdsa_recoverable_signature signature;
 
@@ -54,9 +54,9 @@ std::vector<uint8_t> EthSign::sign(const evm_uint256be hash,
 /**
  * Recover the "from" address from a transaction signature.
  */
-evm_address EthSign::ecrecover(const evm_uint256be hash, const uint8_t version,
-                               const evm_uint256be r,
-                               const evm_uint256be s) const {
+evmc_address EthSign::ecrecover(const evmc_uint256be hash,
+                                const uint8_t version, const evmc_uint256be r,
+                                const evmc_uint256be s) const {
   // parse_compact supports 0-3, but Ethereum is documented as only using 0 and
   // 1
   if (version > 1) {
@@ -64,9 +64,9 @@ evm_address EthSign::ecrecover(const evm_uint256be hash, const uint8_t version,
   }
 
   std::vector<uint8_t> signature;
-  std::copy(r.bytes, r.bytes + sizeof(evm_uint256be),
+  std::copy(r.bytes, r.bytes + sizeof(evmc_uint256be),
             std::back_inserter(signature));
-  std::copy(s.bytes, s.bytes + sizeof(evm_uint256be),
+  std::copy(s.bytes, s.bytes + sizeof(evmc_uint256be),
             std::back_inserter(signature));
 
   secp256k1_ecdsa_recoverable_signature ecsig;
@@ -89,12 +89,12 @@ evm_address EthSign::ecrecover(const evm_uint256be hash, const uint8_t version,
   assert(pubkeysize == 65);
   assert(pubkeysize > 1);
   // skip the version byte at [0]
-  evm_uint256be pubkeyhash =
+  evmc_uint256be pubkeyhash =
       eth_hash::keccak_hash((uint8_t*)(pubkey + 1), pubkeysize - 1);
 
-  evm_address address;
-  std::copy(pubkeyhash.bytes + (sizeof(evm_uint256be) - sizeof(evm_address)),
-            pubkeyhash.bytes + sizeof(evm_uint256be), address.bytes);
+  evmc_address address;
+  std::copy(pubkeyhash.bytes + (sizeof(evmc_uint256be) - sizeof(evmc_address)),
+            pubkeyhash.bytes + sizeof(evmc_uint256be), address.bytes);
 
   return address;
 }
@@ -104,7 +104,7 @@ evm_address EthSign::ecrecover(const evm_uint256be hash, const uint8_t version,
  */
 // bool com::vmware::concord::EthSign::ecverify(const EthTransaction &tx) const
 // {
-//    evm_address recoveredAddr = ecrecover(tx.hash(), tx.sig_v, tx.sig_r,
+//    evmc_address recoveredAddr = ecrecover(tx.hash(), tx.sig_v, tx.sig_r,
 //    tx.sig_s); return recoveredAddr != zero_address && recoveredAddr ==
 //    tx.from;
 // }

--- a/src/utils/concord_eth_sign.hpp
+++ b/src/utils/concord_eth_sign.hpp
@@ -9,7 +9,7 @@
 #include <log4cplus/loggingmacros.h>
 #include <secp256k1.h>
 
-#include "evm.h"
+#include "evmjit.h"
 
 namespace concord {
 namespace utils {
@@ -19,11 +19,11 @@ class EthSign {
   EthSign();
   ~EthSign();
 
-  std::vector<uint8_t> sign(const evm_uint256be hash,
-                            const evm_uint256be key) const;
+  std::vector<uint8_t> sign(const evmc_uint256be hash,
+                            const evmc_uint256be key) const;
 
-  evm_address ecrecover(const evm_uint256be hash, const uint8_t version,
-                        const evm_uint256be r, const evm_uint256be s) const;
+  evmc_address ecrecover(const evmc_uint256be hash, const uint8_t version,
+                         const evmc_uint256be r, const evmc_uint256be s) const;
 
  private:
   log4cplus::Logger logger;

--- a/src/utils/concord_utils.cpp
+++ b/src/utils/concord_utils.cpp
@@ -48,24 +48,24 @@ vector<uint8_t> dehex(const std::string &str) {
   return ret;
 }
 
-/** Converts the given uint64_t into a evm_uint256be type
+/** Converts the given uint64_t into a evmc_uint256be type
     The top 24 bytes are always going to be 0 in this conversion
 */
-void to_evm_uint256be(uint64_t val, evm_uint256be *ret) {
+void to_evmc_uint256be(uint64_t val, evmc_uint256be *ret) {
   uint8_t mask = 0xff;
-  for (size_t i = 0; i < sizeof(evm_uint256be); i++) {
+  for (size_t i = 0; i < sizeof(evmc_uint256be); i++) {
     uint8_t byte = val & mask;
-    ret->bytes[sizeof(evm_uint256be) - i - 1] = byte;  // big endian order
+    ret->bytes[sizeof(evmc_uint256be) - i - 1] = byte;  // big endian order
     val = val >> 8;
   }
 }
 
-/** Converts the given evm_uint256be into a uint64_t, if the value of
+/** Converts the given evmc_uint256be into a uint64_t, if the value of
     @val is more than 2^64 then return value will simply contain the
     lower 8 bytes of @val
 */
-uint64_t from_evm_uint256be(const evm_uint256be *val) {
-  const size_t offset = sizeof(evm_uint256be) - sizeof(uint64_t);
+uint64_t from_evmc_uint256be(const evmc_uint256be *val) {
+  const size_t offset = sizeof(evmc_uint256be) - sizeof(uint64_t);
   uint64_t ret = 0;
   for (size_t i = 0; i < sizeof(uint64_t); i++) {
     ret = ret << 8;
@@ -82,20 +82,20 @@ int64_t get_epoch_millis() {
   return res;
 }
 
-uint256_t to_uint256_t(const evm_uint256be *val) {
+uint256_t to_uint256_t(const evmc_uint256be *val) {
   uint256_t out{0};
   assert(val != nullptr);
-  std::vector<uint8_t> val_v(val->bytes, val->bytes + sizeof(evm_uint256be));
+  std::vector<uint8_t> val_v(val->bytes, val->bytes + sizeof(evmc_uint256be));
   import_bits(out, val_v.begin(), val_v.end());
   return out;
 }
 
-evm_uint256be from_uint256_t(const uint256_t *val) {
-  evm_uint256be out{0};
+evmc_uint256be from_uint256_t(const uint256_t *val) {
+  evmc_uint256be out{0};
   std::vector<uint8_t> val_v;
   assert(val != nullptr);
   export_bits(*val, std::back_inserter(val_v), 8);
-  while (val_v.size() < sizeof(evm_uint256be)) {
+  while (val_v.size() < sizeof(evmc_uint256be)) {
     val_v.insert(val_v.begin(), 0);
   }
   memcpy(out.bytes, val_v.data(), val_v.size());

--- a/src/utils/concord_utils.hpp
+++ b/src/utils/concord_utils.hpp
@@ -19,13 +19,13 @@ namespace utils {
 
 std::vector<uint8_t> dehex(const std::string &str);
 
-void to_evm_uint256be(uint64_t val, evm_uint256be *ret);
+void to_evmc_uint256be(uint64_t val, evmc_uint256be *ret);
 
-uint64_t from_evm_uint256be(const evm_uint256be *val);
+uint64_t from_evmc_uint256be(const evmc_uint256be *val);
 
-evm_uint256be from_uint256_t(const boost::multiprecision::uint256_t *val);
+evmc_uint256be from_uint256_t(const boost::multiprecision::uint256_t *val);
 
-boost::multiprecision::uint256_t to_uint256_t(const evm_uint256be *val);
+boost::multiprecision::uint256_t to_uint256_t(const evmc_uint256be *val);
 
 int64_t get_epoch_millis();
 

--- a/src/utils/rlp.cpp
+++ b/src/utils/rlp.cpp
@@ -76,14 +76,14 @@ void RLPBuilder::add(const std::string &str) {
   add_string_size(str.size());
 }
 
-void RLPBuilder::add(const evm_address &address) {
+void RLPBuilder::add(const evmc_address &address) {
   assert(!finished);
-  add(address.bytes, sizeof(evm_address));
+  add(address.bytes, sizeof(evmc_address));
 }
 
-void RLPBuilder::add(const evm_uint256be &uibe) {
+void RLPBuilder::add(const evmc_uint256be &uibe) {
   assert(!finished);
-  add(uibe.bytes, sizeof(evm_uint256be));
+  add(uibe.bytes, sizeof(evmc_uint256be));
 }
 
 void RLPBuilder::add(uint64_t number) {

--- a/src/utils/rlp.hpp
+++ b/src/utils/rlp.hpp
@@ -8,7 +8,7 @@
 
 #include <memory>
 #include <vector>
-#include "evm.h"
+#include "evmjit.h"
 
 namespace concord {
 namespace utils {
@@ -18,8 +18,8 @@ class RLPBuilder {
   void add(const std::vector<uint8_t> &vec);
   void add(const uint8_t *data, size_t size);
   void add(const std::string &str);
-  void add(const evm_address &address);
-  void add(const evm_uint256be &uibe);
+  void add(const evmc_address &address);
+  void add(const evmc_uint256be &uibe);
   void add(uint64_t number);
   void start_list();
   void end_list();

--- a/test/utils_test.cpp
+++ b/test/utils_test.cpp
@@ -10,10 +10,10 @@ using namespace std;
 using json = nlohmann::json;
 using boost::multiprecision::uint256_t;
 
-using concord::utils::from_evm_uint256be;
+using concord::utils::from_evmc_uint256be;
 using concord::utils::from_uint256_t;
 using concord::utils::RLPBuilder;
-using concord::utils::to_evm_uint256be;
+using concord::utils::to_evmc_uint256be;
 using concord::utils::to_uint256_t;
 
 namespace {
@@ -125,10 +125,10 @@ TEST(rlp_test, example_lipsum) {
   EXPECT_EQ(expect, rlpb.build());
 }
 
-TEST(utils_test, to_evm_uint256be_test) {
+TEST(utils_test, to_evmc_uint256be_test) {
   uint64_t val = 0xabcd1234;
-  evm_uint256be expected;
-  to_evm_uint256be(val, &expected);
+  evmc_uint256be expected;
+  to_evmc_uint256be(val, &expected);
   EXPECT_EQ(expected.bytes[31], 0x34);
   EXPECT_EQ(expected.bytes[30], 0x12);
   EXPECT_EQ(expected.bytes[29], 0xcd);
@@ -138,9 +138,9 @@ TEST(utils_test, to_evm_uint256be_test) {
   }
 }
 
-TEST(utils_test, from_evm_uint256be_test) {
+TEST(utils_test, from_evmc_uint256be_test) {
   uint64_t expected = 0x12121212abcd1234;
-  evm_uint256be val;
+  evmc_uint256be val;
   for (int i = 0; i < 28; i++) {
     val.bytes[i] = 0x12;
   }
@@ -148,11 +148,11 @@ TEST(utils_test, from_evm_uint256be_test) {
   val.bytes[29] = 0xcd;
   val.bytes[30] = 0x12;
   val.bytes[31] = 0x34;
-  EXPECT_EQ(expected, from_evm_uint256be(&val));
+  EXPECT_EQ(expected, from_evmc_uint256be(&val));
 }
 
 TEST(utils_test, to_uint256_t_test) {
-  evm_uint256be input{0};
+  evmc_uint256be input{0};
   input.bytes[31] = 0xef;
   input.bytes[30] = 0xbe;
   input.bytes[29] = 0xad;
@@ -165,13 +165,13 @@ TEST(utils_test, to_uint256_t_test) {
 TEST(utils_test, from_uint256_t_test) {
   uint256_t input{"0xdeadbeef"};
 
-  evm_uint256be expected{0};
+  evmc_uint256be expected{0};
   expected.bytes[31] = 0xef;
   expected.bytes[30] = 0xbe;
   expected.bytes[29] = 0xad;
   expected.bytes[28] = 0xde;
-  evm_uint256be out = from_uint256_t(&input);
-  EXPECT_EQ(0, memcmp(expected.bytes, out.bytes, sizeof(evm_uint256be)));
+  evmc_uint256be out = from_uint256_t(&input);
+  EXPECT_EQ(0, memcmp(expected.bytes, out.bytes, sizeof(evmc_uint256be)));
 }
 
 }  // namespace

--- a/tools/conc_gettxrcpt.cpp
+++ b/tools/conc_gettxrcpt.cpp
@@ -13,7 +13,7 @@
 #include "concmdopt.hpp"
 #include "concord.pb.h"
 
-#include "evm.h"
+#include "evmjit.h"
 
 using namespace boost::program_options;
 using namespace com::vmware::concord;
@@ -34,29 +34,29 @@ void add_options(options_description &desc) {
 
 std::string status_to_string(int32_t status) {
   switch (status) {
-    case EVM_SUCCESS:
+    case EVMC_SUCCESS:
       return "(success)";
-    case EVM_FAILURE:
+    case EVMC_FAILURE:
       return "(failure)";
-    case EVM_OUT_OF_GAS:
+    case EVMC_OUT_OF_GAS:
       return "(out of gas)";
-    case EVM_UNDEFINED_INSTRUCTION:
+    case EVMC_UNDEFINED_INSTRUCTION:
       return "(undefined instruction)";
-    case EVM_BAD_JUMP_DESTINATION:
+    case EVMC_BAD_JUMP_DESTINATION:
       return "(bad jump destination)";
-    case EVM_STACK_OVERFLOW:
+    case EVMC_STACK_OVERFLOW:
       return "(stack overflow)";
-    case EVM_REVERT:
+    case EVMC_REVERT:
       return "(revert)";
-    case EVM_STATIC_MODE_ERROR:
-      return "(static mode error)";
-    case EVM_INVALID_INSTRUCTION:
+    case EVMC_STATIC_MODE_VIOLATION:
+      return "(static mode violation)";
+    case EVMC_INVALID_INSTRUCTION:
       return "(invalid instruction)";
-    case EVM_INVALID_MEMORY_ACCESS:
+    case EVMC_INVALID_MEMORY_ACCESS:
       return "(invalid memory access)";
-    case EVM_REJECTED:
+    case EVMC_REJECTED:
       return "(rejected)";
-    case EVM_INTERNAL_ERROR:
+    case EVMC_INTERNAL_ERROR:
       return "(internal error)";
     default:
       return "(error: unknown status value)";

--- a/tools/ecrecover.cpp
+++ b/tools/ecrecover.cpp
@@ -20,10 +20,10 @@ std::vector<uint8_t> next_part(RLPParser &parser, const char *label) {
   return parser.next();
 }
 
-std::string addr_to_string(evm_address a) {
+std::string addr_to_string(evmc_address a) {
   static const char hexes[] = "0123456789abcdef";
   std::string out;
-  for (size_t i = 0; i < sizeof(evm_address); i++) {
+  for (size_t i = 0; i < sizeof(evmc_address); i++) {
     out.append(hexes + (a.bytes[i] >> 4), 1)
         .append(hexes + (a.bytes[i] & 0x0f), 1);
   }
@@ -80,18 +80,18 @@ int main(int argc, char **argv) {
   uint64_t gas = uint_from_vector(gas_v, "start gas");
   uint64_t value = uint_from_vector(value_v, "value");
 
-  if (r_v.size() != sizeof(evm_uint256be)) {
+  if (r_v.size() != sizeof(evmc_uint256be)) {
     cout << "Signature R is too short (" << r_v.size() << ")" << endl;
     return -1;
   }
-  evm_uint256be r;
+  evmc_uint256be r;
   std::copy(r_v.begin(), r_v.end(), r.bytes);
 
-  if (s_v.size() != sizeof(evm_uint256be)) {
+  if (s_v.size() != sizeof(evmc_uint256be)) {
     cout << "Signature S is too short (" << s_v.size() << ")" << endl;
     return -1;
   }
-  evm_uint256be s;
+  evmc_uint256be s;
   std::copy(s_v.begin(), s_v.end(), s.bytes);
 
   // Figure out non-signed V
@@ -154,10 +154,10 @@ int main(int argc, char **argv) {
 
   // Recover Address
 
-  evm_uint256be unsignedTX_h =
+  evmc_uint256be unsignedTX_h =
       concord::utils::eth_hash::keccak_hash(unsignedTX);
   EthSign verifier;
-  evm_address from = verifier.ecrecover(unsignedTX_h, actualV, r, s);
+  evmc_address from = verifier.ecrecover(unsignedTX_h, actualV, r, s);
 
   cout << "Recovered: " << addr_to_string(from) << endl;
   return 0;

--- a/tools/ecsign.cpp
+++ b/tools/ecsign.cpp
@@ -20,10 +20,10 @@ std::vector<uint8_t> next_part(RLPParser &parser, const char *label) {
   return parser.next();
 }
 
-std::string addr_to_string(evm_address a) {
+std::string addr_to_string(evmc_address a) {
   static const char hexes[] = "0123456789abcdef";
   std::string out;
-  for (size_t i = 0; i < sizeof(evm_address); i++) {
+  for (size_t i = 0; i < sizeof(evmc_address); i++) {
     out.append(hexes + (a.bytes[i] >> 4), 1)
         .append(hexes + (a.bytes[i] & 0x0f), 1);
   }
@@ -65,12 +65,12 @@ int main(int argc, char **argv) {
 
   string key_s(argv[2]);
   vector<uint8_t> key_v = dehex(key_s);
-  if (key_v.size() != sizeof(evm_uint256be)) {
+  if (key_v.size() != sizeof(evmc_uint256be)) {
     cerr << "Key hex not long enough (is " << key_v.size() << " bytes, must be "
-         << sizeof(evm_uint256be) << " bytes)" << endl;
+         << sizeof(evmc_uint256be) << " bytes)" << endl;
     return -1;
   }
-  evm_uint256be key;
+  evmc_uint256be key;
   std::copy(key_v.begin(), key_v.end(), key.bytes);
 
   // Decode RLP
@@ -175,13 +175,13 @@ int main(int argc, char **argv) {
 
   // Sign
 
-  evm_uint256be txhash = concord::utils::eth_hash::keccak_hash(tx);
+  evmc_uint256be txhash = concord::utils::eth_hash::keccak_hash(tx);
   EthSign verifier;
   std::vector<uint8_t> signature = verifier.sign(txhash, key);
 
-  if (signature.size() != 1 + 2 * sizeof(evm_uint256be)) {
+  if (signature.size() != 1 + 2 * sizeof(evmc_uint256be)) {
     cerr << "Signature is not expected length (was " << signature.size()
-         << " bytes, expected " << (1 + 2 * sizeof(evm_uint256be)) << ")"
+         << " bytes, expected " << (1 + 2 * sizeof(evmc_uint256be)) << ")"
          << endl;
     return -1;
   }
@@ -189,10 +189,10 @@ int main(int argc, char **argv) {
   uint64_t v = signature[0];
   std::vector<uint8_t> r;
   std::copy(signature.begin() + 1,
-            signature.begin() + 1 + sizeof(evm_uint256be),
+            signature.begin() + 1 + sizeof(evmc_uint256be),
             std::back_inserter(r));
   std::vector<uint8_t> s;
-  std::copy(signature.begin() + 1 + sizeof(evm_uint256be), signature.end(),
+  std::copy(signature.begin() + 1 + sizeof(evmc_uint256be), signature.end(),
             std::back_inserter(s));
 
   if (v > 1) {


### PR DESCRIPTION
This PR updates the evmjit execution engine to the latest version, commit 4ea7a4

This requires changing some data structures to use a more recent version of the evmc.

In the near future, we should transition to using [Hera](https://github.com/ewasm/hera), which uses a even newer version of the evmc (6.3.1)