### PR TITLE
Update jackson-databind to 2.9.10 (CVE-2019-16335)

### DIFF
--- a/tools/ethrpc/pom.xml
+++ b/tools/ethrpc/pom.xml
@@ -128,12 +128,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.9.9</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.9</version>
+            <version>2.9.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
This PR updates ``com.fasterxml.jackson.core:jackson-databind`` to a version of jackson-databind (2.9.10) which is not vulnerable to CVE-2019-16335 or CVE-2019-14540.