### PR TITLE
Add vim and nano to truffle dockerfile

### DIFF
--- a/docker/dockerfiles/truffle/Dockerfile
+++ b/docker/dockerfiles/truffle/Dockerfile
@@ -1,6 +1,8 @@
 FROM node:12.10.0-stretch AS concord-truffle
 
-RUN npm install -g --unsafe-perm truffle@4.1.16 && \
+RUN RUN apt-get update && apt-get -y install vim nano && \
+    rm -rf /var/lib/apt/lists/* && \
+    npm install -g --unsafe-perm truffle@4.1.16 && \
     mkdir /truffle && \
     cd /truffle && \
     truffle init


### PR DESCRIPTION
This PR adds vim and nano as packages to the truffle dockerfile, making it easier to edit files (and necessary for the tutorials).