### PR TITLE
Use EVMC_MAX_REVISION as default, switch to Truffle5

### DIFF
--- a/docker/dockerfiles/truffle/Dockerfile
+++ b/docker/dockerfiles/truffle/Dockerfile
@@ -2,7 +2,7 @@ FROM node:12.10.0-stretch AS concord-truffle
 
 RUN apt-get update && apt-get -y install vim nano && \
     rm -rf /var/lib/apt/lists/* && \
-    npm install -g --unsafe-perm truffle@4.1.16 && \
+    npm install -g --unsafe-perm truffle && \
     mkdir /truffle && \
     cd /truffle && \
     truffle init

--- a/src/ethereum/concord_evm.cpp
+++ b/src/ethereum/concord_evm.cpp
@@ -302,7 +302,7 @@ evmc_result EVM::execute(evmc_message& message, uint64_t timestamp,
 
   LOG4CPLUS_DEBUG(logger, "EVM execution, code size: " << code.size());
 
-  return evminst->execute(evminst, &concctx.evmctx, EVMC_BYZANTIUM, &message,
+  return evminst->execute(evminst, &concctx.evmctx, EVMC_MAX_REVISION, &message,
                           &code[0], code.size());
 }
 


### PR DESCRIPTION
This PR sets the version of the EVM requested during execution to EVMC_MAX_REVISION.

This enables the use of Truffle 5, which was emitting opcodes in the default migration script not supported in Byzantium. In the future, there should be some mechanism to dynamically select the starting revision and upgrade the blockchain EVM revision globally through a consensus decision.

The version of Truffle set in Docker is upgraded to the latest version of Truffle available (5).