### PR TITLE
Fix Dockerfile

### DIFF
--- a/docker/compose/simple4.yml
+++ b/docker/compose/simple4.yml
@@ -2,6 +2,7 @@ version: '3'
 services:
   concord-truffle:
     image: concord-truffle:latest
+    tty: true
     volumes:
       - ../resources/truffle:/truffle
 

--- a/docker/dockerfiles/truffle/Dockerfile
+++ b/docker/dockerfiles/truffle/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && apt-get -y install vim nano && \
     cd /truffle && \
     truffle init
 
-COPY docker/dockerfiles/truffle/truffle-config.js /truffle/truffle-config.js
-
 WORKDIR /truffle
 
 RUN echo '[ ! -z "$TERM" -a -r /etc/motd ] && cat /etc/issue && cat /etc/motd' \


### PR DESCRIPTION
This PR fixes an issue where the build of the Truffle container fails due to a missing file, and adds a tty line to the simple4.yml file so that the truffle container stays alive instead of exiting.