### PR TITLE
Update docs to use truffle in docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,9 @@ docker/build_images.sh
 docker-compose -f docker/compose/simple4.yml up
 
 # Connect to Concord with Truffle (in a different window)
-docker run -it concord-truffle:latest
+# Or use your own local copy of Truffle and connect to localhost:8545
+docker exec -it compose_concord-truffle_1 bash
 truffle console --network ethrpc1
-
-# Or use your own local copy of Truffle (4.x) and connect to localhost:8545
 ```
 
 Check out our [documentation](https://concord.readthedocs.io/en/latest/) for 

--- a/docs/developer/developer.rst
+++ b/docs/developer/developer.rst
@@ -8,7 +8,7 @@ Developer
           link on the top right.
 
 Concord is developed inside of Docker containers to simplify dependency management, and the easiest way to get 
-a development environment setup for Concord is by using `Visual Studio Code <https://code.visualstudio.com/>`, 
+a development environment setup for Concord is by using `Visual Studio Code <https://code.visualstudio.com/>`_, 
 which includes Dev Container features, making it easy to deploy and debug from within a container.
 
 Concord has a ``devcontainer.json`` file included in the repository which will correctly setup the container

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -30,9 +30,6 @@ You should see some messages go by, indicating the cluster is starting up. Once 
 is up, the next setup is to interact with it. Since this cluster comes with the ``ethRPC`` bridge,
 we can communciate with it using standard Ethereum tooling.
 
-.. attention:: The ``ethRPC`` bridge currently only supports Truffle 4.x. Connecting with a newer version
-               of Truffle will result in connection errors.
-
 `Truffle <https://www.npmjs.com/package/truffle>`_ is a popular tool for developing and debugging
 Ethereum smart contracts. If you're familar with Truffle (note that we only support Truffle 4.x at the moment)
 and have used it before, you can connect to the blockchain instance on your local machine 
@@ -41,15 +38,14 @@ at http://localhost:8545, which will connect to the first Concord node in your s
 Otherwise, the repository contains a docker image with Truffle pre-installed to deploy to the simple
 4 node Concord instance you just created. To start the image and connect to the first Concord node, run:: 
  
-   docker run -it concord-truffle:latest
+   docker exec -it compose_concord-truffle_1 bash
    truffle console  --network ethrpc1
 
 .. highlight:: javascript
 Now you can run a test transaction using Truffle. Type the following in the Truffle console:: 
  
    var accounts = await web3.eth.getAccounts()
-   await web3.eth.sendTransaction({from: accounts[0], to: accounts[1], value: web3.utils.toWei("0", "ether")})   
-   web3.eth.getTransaction(tx)
+   await web3.eth.sendTransaction({from: accounts[0], to: accounts[1], value: web3.utils.toWei("0", "ether")})
 
 You should get ouptut similar to::
 

--- a/docs/tutorials/tutorials.rst
+++ b/docs/tutorials/tutorials.rst
@@ -18,7 +18,7 @@ Start by running the simple four node Concord instance, ``simple4.yml`` from the
 
 Next, start the truffle image::
 
-   docker run -it concord-truffle:latest
+   docker exec -it compose_concord-truffle_1 bash
 
 We'll now create a simple hello world contract. We'll use ``vim`` to create the contract, which
 needs to be inserted in the contracts directory::


### PR DESCRIPTION
This PR updates the docs to use the Truffle image provided in docker-compose.