### PR TITLE
Update jackson-databind dep in ethrpc

### DIFF
--- a/tools/ethrpc/pom.xml
+++ b/tools/ethrpc/pom.xml
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.9.10</version>
+            <version>2.9.10.1</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Github reports that jackson-databind versions prior to 2.9.10.1 are
vulnerable to:

https://github.com/advisories/GHSA-gjmw-vf9h-g25v
https://github.com/advisories/GHSA-fmmc-742q-jg75
https://github.com/advisories/GHSA-mx7p-6679-8g3q

